### PR TITLE
Revert "Bump guava from 24.1.1-jre to 29.0-jre"

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -237,7 +237,7 @@
     <dependency>
       <groupId>com.google.guava</groupId>
       <artifactId>guava</artifactId>
-      <version>29.0-jre</version>
+      <version>24.1.1-jre</version>
     </dependency>
     <dependency>
       <groupId>com.google.protobuf</groupId>


### PR DESCRIPTION
Reverts vend/maxwell#10

Looks like the new version of guava is not compatible with this repo, so rolling it back.