### PR TITLE
Set owner field in catalog-info.yaml to "platform"

### DIFF
--- a/catalog-info.yaml
+++ b/catalog-info.yaml
@@ -9,5 +9,5 @@ metadata:
 spec:
   type: service
   lifecycle: production
-  owner: sre
+  owner: platform
   system: maxwell


### PR DESCRIPTION
Changing owner to "platform" in catalog-info.yaml as a result of merging the "dx" and "sre" teams.

https://vendhq.atlassian.net/browse/PLAT-1722